### PR TITLE
Add optional argument to initialize to specify interested data types

### DIFF
--- a/EosSyncLib/EosSyncLib.cpp
+++ b/EosSyncLib/EosSyncLib.cpp
@@ -1152,6 +1152,10 @@ void EosTargetList::InitializeAsDummy()
 
 EosSyncData::EosSyncData()
 {
+	for (unsigned int i = 0; i < EosTarget::EOS_TARGET_COUNT; i++)
+	{
+		m_Types.push_back(static_cast<EosTarget::EnumEosTargetType>(i));
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1182,9 +1186,8 @@ void EosSyncData::Initialize()
 	Clear();
 
 	// add default targets	
-	for(unsigned int i=0; i<EosTarget::EOS_TARGET_COUNT; i++)
+	for(EosTarget::EnumEosTargetType type : m_Types)
 	{
-		EosTarget::EnumEosTargetType type = static_cast<EosTarget::EnumEosTargetType>(i);
 		if(type != EosTarget::EOS_TARGET_CUE)
 			m_ShowData[type][0] = new EosTargetList(type, /*listId*/0);
 	}
@@ -1540,6 +1543,13 @@ void EosSyncData::ClearDirty()
 	}
 }
 
+void EosSyncData::SetSubscribedTypes(const EosTarget::TYPE_LIST& list)
+{
+	Clear();
+	m_Status.SetValue(EosSyncStatus::EnumSyncStatus::SYNC_STATUS_UNINTIALIZED);
+	m_Types = list;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 EosSyncLib::EosSyncLib()
@@ -1559,8 +1569,12 @@ EosSyncLib::~EosSyncLib()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool EosSyncLib::Initialize(const char *ip, unsigned short port)
+bool EosSyncLib::Initialize(const char *ip, unsigned short port, const EosTarget::TYPE_LIST* list)
 {
+	if (list)
+	{
+		m_Data.SetSubscribedTypes(*list);
+	}
 	return m_Tcp->Initialize(m_Log,ip, port);
 }
 

--- a/EosSyncLib/EosSyncLib.h
+++ b/EosSyncLib/EosSyncLib.h
@@ -93,6 +93,8 @@ public:
 		EOS_TARGET_INVALID
 	};
 
+	typedef std::vector<EnumEosTargetType> TYPE_LIST;
+
 	struct sDecimalNumber
 	{
 		sDecimalNumber() : whole(0), decimal(0) {}
@@ -241,10 +243,12 @@ public:
 	virtual const SHOW_DATA& GetShowData() const {return m_ShowData;}
 	virtual const EosTargetList* GetTargetList(EosTarget::EnumEosTargetType type, int listId) const;
 	virtual void ClearDirty();
+	virtual void SetSubscribedTypes(const EosTarget::TYPE_LIST& list);
 
 private:
 	EosSyncStatus	m_Status;
 	SHOW_DATA		m_ShowData;
+	EosTarget::TYPE_LIST m_Types;
 
 	virtual void Initialize();
 	virtual void TickRunning(EosTcp &tcp, EosOsc &osc, EosLog &log);
@@ -268,7 +272,7 @@ public:
 	EosSyncLib();
 	virtual ~EosSyncLib();
 
-	virtual bool Initialize(const char *ip, unsigned short port);
+	virtual bool Initialize(const char *ip, unsigned short port, const EosTarget::TYPE_LIST* list = nullptr);
 	virtual void Shutdown();
 	virtual void Tick();
 	virtual bool IsRunning() const;


### PR DESCRIPTION
For larger shows, it's useful to be able to specify only a limited set of data types we're interested in. 